### PR TITLE
[COOK-3505] Specify the administrator account name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ server
 * `node['sql_server']['port']` - static TCP port server should listen on for client connections, default is `1433`
 * `node['sql_server']['instance_name']` - name of the default instance, default is `SQLEXPRESS`
 * `node['sql_server']['instance_dir']` - root directory of the default instance, default is `C:\Program Files\Microsoft SQL Server`
+* `node['sql_server']['sql_admin_accounts']` - Specifies the Windows administrator account names to set as SQL SysAdmins, default is `Administrator`
 
 This file also contains download url, checksum and package name for the server installation package.
 

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -26,6 +26,8 @@ default['sql_server']['instance_dir']   = 'C:\Program Files\Microsoft SQL Server
 
 default['sql_server']['feature_list'] = 'SQLENGINE,REPLICATION,SNAC_SDK'
 
+default['sql_server']['sql_admin_accounts'] = 'Administrator'
+
 if kernel['machine'] =~ /x86_64/
 
   default['sql_server']['server']['url']          = 'http://care.dlservice.microsoft.com/dl/download/5/1/A/51A153F6-6B08-4F94-A7B2-BA1AD482BC75/SQLEXPR_x64_ENU.exe'

--- a/templates/default/ConfigurationFile.ini.erb
+++ b/templates/default/ConfigurationFile.ini.erb
@@ -158,8 +158,7 @@ SQLSVCACCOUNT="NT AUTHORITY\NETWORK SERVICE"
 
 ; Windows account(s) to provision as SQL Server system administrators.
 
-;SQLSYSADMINACCOUNTS="IP-0A7A5B97\Administrator"
-SQLSYSADMINACCOUNTS="Administrator"
+SQLSYSADMINACCOUNTS="<%= node['sql_server']['sql_admin_accounts'] %>"
 
 ; Provision current user as a Database Engine system administrator for SQL Server 2008 R2 Express.
 


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3505

By default, the Windows account used as SysAdmin is 'Administrator', but on the http://www.vagrantbox.es/ boxes, it is named 'vagrant', so the installation crashes.
This improvement suggests providing a way to specify the Windows account name in the config file, for example:
```ruby
default_attributes(
  "sql_server" => {
    "accept_eula" => true,
    "sql_admin_accounts" => 'vagrant'
  }
```