### PR TITLE
[GH-36] - 'Fixed' 2 ChefSpec tests failing on Windows

### DIFF
--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -39,7 +39,7 @@ describe 'sql_server::server' do
 
     it 'creates the correct ConfigurationFile.ini template' do
       expect(chef_run).to create_template('C:\chef\cache\ConfigurationFile.ini')
-      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^SQLSYSADMINACCOUNTS="Administrator Fred Barney"$/)
+      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^SQLSYSADMINACCOUNTS="Administrator Fred Barney"/)
     end
 
     it 'converges successfully' do
@@ -57,7 +57,7 @@ describe 'sql_server::server' do
 
     it 'creates the correct ConfigurationFile.ini template' do
       expect(chef_run).to create_template('C:\chef\cache\ConfigurationFile.ini')
-      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^SQLSYSADMINACCOUNTS="Administrator"$/)
+      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^SQLSYSADMINACCOUNTS="Administrator"/)
     end
 
     it 'converges successfully' do


### PR DESCRIPTION
As per https://github.com/sethvargo/chefspec/issues/373 the two checks for values of "SQLSYSADMINACCOUNTS" fail due to the `$` to match the end of line in the regex with the following:
```
rspec ./spec/unit/recipes/server_spec.rb:40 # sql_server::server When specifying an Array of admin users for "sysadmins" creates the correct ConfigurationFile.ini template
rspec ./spec/unit/recipes/server_spec.rb:58 # sql_server::server When specifying a String for "sysadmins" creates the correct ConfigurationFile.ini template
```