### PR TITLE
Fix tests for array of sysadmin name

### DIFF
--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -44,7 +44,7 @@ describe 'sql_server::server' do
 
     it 'creates the correct ConfigurationFile.ini template' do
       expect(chef_run).to create_template('C:\chef\cache\ConfigurationFile.ini')
-      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^SQLSYSADMINACCOUNTS="Administrator Fred Barney"/)
+      expect(chef_run).to render_file('C:\chef\cache\ConfigurationFile.ini').with_content(/^SQLSYSADMINACCOUNTS="Administrator" "Fred" "Barney"/)
     end
 
     it 'converges successfully' do


### PR DESCRIPTION
With PR#57 SQLSYSADMINACCOUNTS properly handle multiple admin names but
tests were not updated accordingly.

cc: @aboten