### PR TITLE
Specify restart_command for SQL service

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -102,6 +102,7 @@ end
 
 service service_name do
   action [:start, :enable]
+  restart_command %(powershell.exe -C "restart-service '#{service_name}' -force")
 end
 
 include_recipe 'sql_server::client'


### PR DESCRIPTION
Some changes might require SQL Service restart which is not doable yet, because SQLAgent service depends on SQL Service.
Using the `-force` parameter of the `restart-service` powershell cmdlet allows the restart of both services.

Tests won't pass until #60 has been merged.

cc: @aboten