### PR TITLE
Add more server configuration in a separate recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ This file also contains download url, checksum and package name for all client i
 ### server
 
 - `node['sql_server']['install_dir']` - main directory for installation, default is `C:\Program Files\Microsoft SQL Server`
-- `node['sql_server']['port']` - static TCP port server should listen on for client connections, default is `1433`
 - `node['sql_server']['instance_name']` - name of the default instance, default is `SQLEXPRESS`
 - `node['sql_server']['instance_dir']` - root directory of the default instance, default is `C:\Program Files\Microsoft SQL Server`
 - `node['sql_server']['shared_wow_dir']` - root directory of the shared WOW directory, default is `C:\Program Files (x86)\Microsoft SQL Server`
@@ -49,6 +48,16 @@ This file also contains download url, checksum and package name for all client i
 - `node['sql_server']['sql_account']` - SQL service account name, default is `NT AUTHORITY\NETWORK SERVICE`
 
 This file also contains download url, checksum and package name for the server installation package.
+
+### configure
+- `node['sql_server']['tcp_enabled']` - Enables TCP listener, default is `true`
+- `node['sql_server']['port']` - Static TCP port server should listen on for client connections, default is `1433`
+- `node['sql_server']['tcp_dynamic_ports']` - Dynamic TCP ports server should listen on for client connections, default is `''`
+- `node['sql_server']['np_enabled']` - Enables Named pipes listener, default is `false`
+- `node['sql_server']['sm_enabled']` - Enables Shared Memory listener, default is `true`
+- `node['sql_server']['via_default_port']` - VIA default listener port, default is `0:1433`
+- `node['sql_server']['via_enabled']` - Enables VIA listener, default is `false`
+- `node['sql_server']['via_listen_info']` - VIA listener info, default is `0:1433`
 
 ## Usage
 
@@ -67,6 +76,17 @@ Installs required the SQL Server Native Client and all required dependancies. Th
 - [Windows PowerShell Extensions for SQL Server 2008 R2](http://www.microsoft.com/download/en/details.aspx?id=16978#PowerShell)
 
 The SQL Server Native Client contains the SQL Server ODBC driver and the SQL Server OLE DB provider in one native dynamic link library (DLL) supporting applications using native-code APIs (ODBC, OLE DB and ADO) to Microsoft SQL Server. In simple terms these packages should allow any other node to act as a client of a SQL Server instance.
+
+### configure
+Configures SQL Server registry keys via attributes, and restart the Engine service if required.
+
+Current supported settings are mostly connection listeners:
+- TCP or VIA listener ports
+- TCP, Named Pipes, Shared Memory or VIA listener activation.
+
+NOTE: It could be very dangerous to change these settings on a production server!
+
+This recipe is included by the `sql_server::server` recipe, but can be included independently if you setup SQL Server by yourself.
 
 ### server
 
@@ -92,7 +112,7 @@ The installation is done using the `package` resource and [ConfigurationFile](ht
 
 - Enables [Mixed Mode](http://msdn.microsoft.com/en-us/library/aa905171\(v=sql.80\).aspx) (Windows Authentication and SQL Server Authentication) authentication
 - Auto-generates and sets a strong password for the 'sa' account
-- sets a static TCP port which is configurable via an attribute.
+- sets a static TCP port which is configurable via an attribute, using the `sql_server::configure` recipe.
 
 Installing any of the SQL Server server or client packages in an unattended/automated way requires you to explicitly indicate that you accept the terms of the end user license. The hooks have been added to all recipes to do this via an attribute. Create a role to set the `node['sql_server']['accept_eula']` attribute to 'true'. For example:
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ namespace :style do
     FoodCritic::Rake::LintTask.new(:chef) do |t|
       t.options = {
         fail_tags: ['any'],
-        progress: true
+        progress: true,
       }
     end
   rescue LoadError

--- a/attributes/configure.rb
+++ b/attributes/configure.rb
@@ -1,0 +1,32 @@
+#
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+# Cookbook Name:: sql_server
+# Attribute:: configure
+#
+# Copyright:: Copyright (c) 2011-2016 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Tcp settings
+default['sql_server']['tcp_enabled']       = true
+default['sql_server']['port']              = 1433 # Keep port for backward compatibility
+default['sql_server']['tcp_dynamic_ports'] = ''
+# Named Pipes settings
+default['sql_server']['np_enabled']        = false
+# Shared Memory settings
+default['sql_server']['sm_enabled']        = true
+# Via settings
+default['sql_server']['via_default_port']  = '0:1433'
+default['sql_server']['via_enabled']       = false
+default['sql_server']['via_listen_info']   = '0:1433'

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -19,8 +19,6 @@
 #
 
 default['sql_server']['install_dir']    = 'C:\Program Files\Microsoft SQL Server'
-default['sql_server']['port']           = 1433
-
 default['sql_server']['instance_name']  = 'SQLEXPRESS'
 default['sql_server']['instance_dir']   = 'C:\Program Files\Microsoft SQL Server'
 default['sql_server']['shared_wow_dir'] = 'C:\Program Files (x86)\Microsoft SQL Server'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,0 +1,78 @@
+#
+# Author:: Baptiste Courtois (<b.courtois@criteo.com>)
+# Cookbook Name:: sql_server
+# Recipe:: configure
+#
+# Copyright:: 2011-2016, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+instance = node['sql_server']['instance_name']
+
+# Compute service name based on sql server instance name
+service_name = (instance != 'MSSQLSERVER') ? "MSSQL$#{instance}" : instance
+
+# Agent name needs to be declared because if you use the SQL Agent, you need
+# to restart both services as the Agent is dependent on the SQL Service
+agent_service_name = (instance == 'MSSQLSERVER') ? 'SQLSERVERAGENT' : "SQLAgent$#{instance}"
+
+# Compute registry version based on sql server version
+reg_version = node['sql_server']['reg_version'] || ::SqlServer::Helper.reg_version_string(node['sql_server']['version'])
+
+reg_prefix = "HKLM\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\#{reg_version}#{instance}\\MSSQLServer"
+
+# Configure Tcp settings - static tcp ports
+registry_key "#{reg_prefix}\\SuperSocketNetLib\\Tcp\\IPAll" do
+  values [{ name: 'Enabled', type: :dword, data: node['sql_server']['tcp_enabled'] ? 1 : 0 },
+          { name: 'TcpPort', type: :string, data: node['sql_server']['port'].to_s },
+          { name: 'TcpDynamicPorts', type: :string, data: node['sql_server']['tcp_dynamic_ports'].to_s }]
+  recursive true
+  notifies :restart, "service[#{service_name}]", :immediately
+end
+
+# Configure Named Pipes settings
+registry_key "#{reg_prefix}\\SuperSocketNetLib\\Np" do
+  values [{ name: 'Enabled', type: :dword, data: node['sql_server']['np_enabled'] ? 1 : 0 }]
+  recursive true
+  notifies :restart, "service[#{service_name}]", :immediately
+end
+
+# Configure Shared Memory settings
+registry_key "#{reg_prefix}\\SuperSocketNetLib\\Sm" do
+  values [{ name: 'Enabled', type: :dword, data: node['sql_server']['sm_enabled'] ? 1 : 0 }]
+  recursive true
+  notifies :restart, "service[#{service_name}]", :immediately
+end
+
+# Configure Via settings
+registry_key "#{reg_prefix}\\SuperSocketNetLib\\Via" do
+  values [{ name: 'DefaultServerPort', type: :string, data: node['sql_server']['via_default_port'].to_s },
+          { name: 'Enabled', type: :dword, data: node['sql_server']['via_enabled'] ? 1 : 0 },
+          { name: 'ListenInfo', type: :string, data: node['sql_server']['via_listen_info'].to_s }]
+  recursive true
+  notifies :restart, "service[#{service_name}]", :immediately
+end
+
+# If you have declared an agent account it will restart both the
+# agent service and the sql service. If not only the sql service
+if node['sql_server']['agent_account']
+  service agent_service_name do
+    action [:start, :enable]
+  end
+end
+
+service service_name do
+  action [:start, :enable]
+  restart_command %(powershell.exe -C "restart-service '#{service_name}' -force")
+end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -20,25 +20,6 @@
 
 Chef::Application.fatal!("node['sql_server']['server_sa_password'] must be set for this cookbook to run") if node['sql_server']['server_sa_password'].nil?
 
-# SQLEXPRESS is used as an instance name in Standard or Enterprise installs
-# SQL Server it will default to MSSQLSERVER. Any instance name used will
-# have MSSQ$ appeneded to the front
-service_name = if node['sql_server']['instance_name'] == 'MSSQLSERVER'
-                 node['sql_server']['instance_name']
-               else
-                 "MSSQL$#{node['sql_server']['instance_name']}"
-               end
-# Agent name needs to be declared because if you use the SQL Agent, you need
-# to restart both services as the Agent is dependent on the SQL Service
-agent_service_name = if node['sql_server']['instance_name'] == 'MSSQLSERVER'
-                       'SQLSERVERAGENT'
-                     else
-                       "SQLAgent$#{node['sql_server']['instance_name']}"
-                     end
-
-static_tcp_reg_key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SQL Server\\' + SqlServer::Helper.reg_version_string(node['sql_server']['version']) +
-                     node['sql_server']['instance_name'] + '\MSSQLServer\SuperSocketNetLib\Tcp\IPAll'
-
 config_file_path = win_friendly_path(File.join(Chef::Config[:file_cache_path], 'ConfigurationFile.ini'))
 
 sql_sys_admin_list = if node['sql_server']['sysadmins'].is_a? Array
@@ -74,7 +55,7 @@ package_checksum = node['sql_server']['server']['checksum'] ||
 passwords_options = {
   AGTSVCPASSWORD: node['sql_server']['agent_account_pwd'],
   RSSVCPASSWORD:  node['sql_server']['rs_account_pwd'],
-  SQLSVCPASSWORD: node['sql_server']['sql_account_pwd']
+  SQLSVCPASSWORD: node['sql_server']['sql_account_pwd'],
 }.map do |option, attribute|
   next unless attribute
   # Escape password double quotes and backslashes
@@ -95,29 +76,10 @@ package package_name do
   returns [0, 42, 127, 3010]
 end
 
-# set the static tcp port
-registry_key static_tcp_reg_key do
-  values [{ name: 'TcpPort', type: :string, data: node['sql_server']['port'].to_s },
-          { name: 'TcpDynamicPorts', type: :string, data: '' }]
-  recursive true
-  notifies :restart, "service[#{service_name}]", :immediately
-end
-
-# If you have declared an agent account it will restart both the
-# agent service and the sql service. If not only the sql service
-if node['sql_server']['agent_account']
-  service agent_service_name do
-    action [:start, :enable]
-  end
-end
-
-service service_name do
-  action [:start, :enable]
-  restart_command %(powershell.exe -C "restart-service '#{service_name}' -force")
-end
-
 # SQL Server requires a reboot to complete your install
 reboot 'sql server install' do
   action :nothing
   reason 'Needs to reboot after installing SQL Server'
 end
+
+include_recipe 'sql_server::configure'


### PR DESCRIPTION
Content of this PR:
- Move server configuration in a new `sql_server::configure` recipe.
- Add attributes to control network listeners via registry keys.
- Fix service name when using named instance.
- Set service restart command to allow restart when SQL Agent is present.
- Update README accordingly.

To avoid conflicts it replaces #59 and #61, and fixes #39
Tests will not pass until #60 is merged

cc: @aboten
