### PR TITLE
Updates for Standard Edition

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -20,8 +20,8 @@
 
 Chef::Application.fatal!("node['sql_server']['server_sa_password'] must be set for this cookbook to run") if node['sql_server']['server_sa_password'].nil?
 
-# SQLEXPRESS is used as an instance name in Standard or Enterprise installs 
-# SQL Server it will default to MSSQLSERVER. Any instance name used will 
+# SQLEXPRESS is used as an instance name in Standard or Enterprise installs
+# SQL Server it will default to MSSQLSERVER. Any instance name used will
 # have MSSQ$ appeneded to the front
 service_name = if node['sql_server']['instance_name'] == 'MSSQLSERVER'
                  node['sql_server']['instance_name']
@@ -31,10 +31,10 @@ service_name = if node['sql_server']['instance_name'] == 'MSSQLSERVER'
 # Agent name needs to be declared because if you use the SQL Agent, you need
 # to restart both services as the Agent is dependent on the SQL Service
 agent_service_name = if node['sql_server']['instance_name'] == 'MSSQLSERVER'
-                 'SQLSERVERAGENT'
-               else
-                 "SQLAgent$#{node['sql_server']['instance_name']}"
-               end
+                       'SQLSERVERAGENT'
+                     else
+                       "SQLAgent$#{node['sql_server']['instance_name']}"
+                     end
 
 # Compute registry version based on sql server version
 reg_version = node['sql_server']['reg_version'] ||
@@ -121,10 +121,10 @@ if node['sql_server']['agent_account']
   service service_name do
     action [:start, :enable]
   end
-else
-  service service_name do
-    action [:start, :enable]
-  end
+end
+
+service service_name do
+  action [:start, :enable]
 end
 
 # SQL Server requires a reboot to complete your install


### PR DESCRIPTION
### Description

Instance name is modified because SQLEXPRESS is used as an instance name for SQL Server. In Standard or Enterprise installs, SQL Server will default to MSSQLSERVER. Any instance name declared by the user will have MSSQL$ appeneded to the front as the service name.
Agent name needs to be declared because if you use the SQL Agent, you need to restart both services as the Agent is dependent on the SQL Service
If you have declared an agent account it will restart both the agent service and the sql service. If not only restart the sql service
Also added return codes because the install periodically returns 3010 which means a reboot is pending and is not an actual error, the other return codes were taken from the chef output.
SQL Server requires a reboot to complete your install

### Issues Resolved

N/A

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD 
-- tested with test kitchen and also locally
- [x] New functionality includes testing. 
-- same testing as before. the out of the box cookbook doesn't work for standard or enterprise if you use instance names other than MSSQLSERVER which is the default.
- [n/a] New functionality has been documented in the README if applicable 
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


