### PR TITLE
cleaning up duplicate service restart for sql service

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -118,9 +118,6 @@ if node['sql_server']['agent_account']
   service agent_service_name do
     action [:start, :enable]
   end
-  service service_name do
-    action [:start, :enable]
-  end
 end
 
 service service_name do


### PR DESCRIPTION
### Description

Cleaning up sql service restart in the block that restarts the agent. 

### Issues Resolved

From a note on PR #67 

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


