### PR TITLE
Only start and enable agent if agent_startup is set to automatic

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -66,7 +66,7 @@ end
 
 # If you have declared an agent account it will restart both the
 # agent service and the sql service. If not only the sql service
-if node['sql_server']['agent_account']
+if node['sql_server']['agent_startup'] == 'Automatic'
   service agent_service_name do
     action [:start, :enable]
   end


### PR DESCRIPTION
Signed-off-by: Eric Blevins <eblevins@kmilearning.com>

### Description

Only start and enable agent if agent_startup is set to automatic

### Issues Resolved

Issue 73

### Check List

- [ x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [n/a ] New functionality includes testing.
- [n/a ] New functionality has been documented in the README if applicable
- [x ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
