### PR TITLE
Fix kitchen failure for client-windows-2008r2 by installing NetFx3.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,11 +18,11 @@ platforms:
   - name: windows-2012r2
     driver_config:
       box: chef/windows-server-2012r2-standard
-  - name: windows-2012r2-chef-12.6
-    driver_config:
-      box: chef/windows-server-2012r2-standard
-    provisioner:
-      require_chef_omnibus: 12.6.0
+  # - name: windows-2012r2-chef-12.6
+  #   driver_config:
+  #     box: chef/windows-server-2012r2-standard
+  #   provisioner:
+  #     require_chef_omnibus: 12.6.0
 
 suites:
   - name: client

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@ transport:
 
 provisioner:
   name: chef_zero
+  # deprecations_as_errors: true
 
 platforms:
   - name: windows-2008r2
@@ -18,11 +19,11 @@ platforms:
   - name: windows-2012r2
     driver_config:
       box: chef/windows-server-2012r2-standard
-  # - name: windows-2012r2-chef-12.6
-  #   driver_config:
-  #     box: chef/windows-server-2012r2-standard
-  #   provisioner:
-  #     require_chef_omnibus: 12.6.0
+  - name: windows-2012r2-chef-12.6
+    driver_config:
+      box: chef/windows-server-2012r2-standard
+    provisioner:
+      require_chef_omnibus: 12.6.0
 
 suites:
   - name: client

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -18,12 +18,17 @@
 # limitations under the License.
 #
 
-nt_version = ::Windows::VersionHelper.nt_version(node)
-
-if nt_version == 6.1
+def netfx_install
   windows_feature 'NetFx3' do
     action :install
   end
+end
+
+case node['platform_version']
+when '6.1.7600'
+  netfx_install
+when '6.1.7601'
+  netfx_install
 end
 
 %w( native_client command_line_utils clr_types smo ps_extensions ).each do |pkg|

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -18,6 +18,14 @@
 # limitations under the License.
 #
 
+nt_version = ::Windows::VersionHelper.nt_version(node)
+
+if nt_version == 6.1
+  windows_feature 'NetFx3' do
+    action :install
+  end
+end
+
 %w( native_client command_line_utils clr_types smo ps_extensions ).each do |pkg|
   package node['sql_server'][pkg]['package_name'] do
     source node['sql_server'][pkg]['url']

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -18,17 +18,10 @@
 # limitations under the License.
 #
 
-def netfx_install
+if node['platform_version'].to_f == 6.1
   windows_feature 'NetFx3' do
     action :install
   end
-end
-
-case node['platform_version']
-when '6.1.7600'
-  netfx_install
-when '6.1.7601'
-  netfx_install
 end
 
 %w( native_client command_line_utils clr_types smo ps_extensions ).each do |pkg|


### PR DESCRIPTION
Signed-off-by: John Snow <jsnow@chef.io>

### Description

In the client recipe I added an install for NetFx3 so that the smo package will install with out error.

### Issues Resolved

Fixes issue with 2008R2 install of client.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
