### PR TITLE
Update password in kitchen to support SQL SA password requirements.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,16 +33,16 @@ suites:
   - name: server2008r2
     run_list:
       - recipe[sql_server::server]
-    attributes: { sql_server: { accept_eula: true, version: 2008R2, server_sa_password: supersecurepassword123 } }
+    attributes: { sql_server: { accept_eula: true, version: 2008R2, server_sa_password: Supersecurepassword123 } }
   - name: server2012
     run_list:
       - recipe[sql_server::server]
-    attributes: { sql_server: { accept_eula: true, version: 2012, server_sa_password: supersecurepassword123 } }
+    attributes: { sql_server: { accept_eula: true, version: 2012, server_sa_password: Supersecurepassword123 } }
   - name: server2014
     run_list:
       - recipe[sql_server::server]
-    attributes: { sql_server: { accept_eula: true, version: 2014, server_sa_password: supersecurepassword123 } }
+    attributes: { sql_server: { accept_eula: true, version: 2014, server_sa_password: Supersecurepassword123 } }
   - name: server2016
     run_list:
       - recipe[sql_server::server]
-    attributes: { sql_server: { accept_eula: true, version: 2016, server_sa_password: supersecurepassword123 } }
+    attributes: { sql_server: { accept_eula: true, version: 2016, server_sa_password: Supersecurepassword123 } }


### PR DESCRIPTION
Signed-off-by: John Snow <jsnow@chef.io>

### Description

This change meets the passwords requirements for SQL SA mode for SQL express. Currently SQL will fail if the server_sa_password attribute doesn't contain three of the 4 available character options(1 uppercase, 1 lowercase, 1 special character, and 1 number) and has the correct length.

### Issues Resolved

Running test-kitchen will fail during server install weird error. I attempted to run the install command and got the same error with a note that the password did not meet the SQL SA password requirements.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
