### PR TITLE
Update SQL 2016 url and checksum and fix Readme.

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -17,9 +17,4 @@ suites:
   - name: client
     run_list:
       - recipe[sql_server::default]
-    attributes: { sql_server: { accept_eula: true } }
-  - name: server2016
-    run_list:
-      - recipe[sql_server::server]
-    attributes: { sql_server: { accept_eula: true, version: 2016, server_sa_password: Supersecurepassword123 } }
-    
+    attributes: { sql_server: { accept_eula: true } }  

--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -18,3 +18,8 @@ suites:
     run_list:
       - recipe[sql_server::default]
     attributes: { sql_server: { accept_eula: true } }
+  - name: server2016
+    run_list:
+      - recipe[sql_server::server]
+    attributes: { sql_server: { accept_eula: true, version: 2016, server_sa_password: Supersecurepassword123 } }
+    

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Installs and configures Microsoft SQL Server 2008 R2 SP2 and Microsoft SQL Serve
 
 - Windows Server 2008 R2 (SP2)
 - Windows Server 2012 (R1, R2)
+NOTE: SQL Server 2016 is not supported on Server 2012 R1 and R2
 
 ### Chef
 
@@ -90,7 +91,7 @@ This recipe is included by the `sql_server::server` recipe, but can be included 
 
 ### server
 
-Installs SQL Server 2008 R2 Express or SQL Server 2012 Express.
+Installs SQL Server 2008 R2 Express, SQL Server 2012 Express, SQL Server 2014 Express, or SQL Server 2016 Express.
 
 By default, the cookbook installs SQL Server 2008 R2 Express. There are two options to install a different version.
 
@@ -98,7 +99,7 @@ NOTE: For this recipe to run you must set the node['sql_server']['server_sa_pass
 
 NOTE: This recipe will request a reboot at the end of the Chef Client run if SQL Server was installed.. If you do not want to reboot after the installation, use the `reboot` resource to cancel the pending reboot.
 
-**Option 1:** From a role, environment, or wrapper cookbook, set `node['sql_server']['version']` to '2008R2' to install SQL Server 2008 R2 Express, '2012' to install SQL Server 2012 Express or '2014' to install SQL Server 2014 Express.
+**Option 1:** From a role, environment, or wrapper cookbook, set `node['sql_server']['version']` to '2008R2' to install SQL Server 2008 R2 Express, '2012' to install SQL Server 2012 Express, '2014' to install SQL Server 2014 Express, or '2016' to install SQL Server 2016 Express.
 
 **Option 2:** From a role, environment, or wrapper cookbook, set these node attributes to specify the URL, checksum, and name of the package (as it appears in the Windows Registry).
 
@@ -173,7 +174,7 @@ SQL Server does not support remote installation over WinRM. For example, the ins
 
 **Author:** Cookbook Engineering Team ([cookbooks@chef.io](mailto:cookbooks@chef.io))
 
-**Copyright:** 2011-2016, Chef Software, Inc.
+**Copyright:** 2011-2017, Chef Software, Inc.
 
 ```text
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installs and configures Microsoft SQL Server 2008 R2 SP2 and Microsoft SQL Serve
 
 - Windows Server 2008 R2 (SP2)
 - Windows Server 2012 (R1, R2)
-NOTE: SQL Server 2016 is not supported on Server 2012 R1 and R2
+NOTE: Install of SQL Server 2016 is not supported on Server 2008 R2
 
 ### Chef
 

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -56,7 +56,7 @@ module SqlServer
         when '2008R2' then 'https://download.microsoft.com/download/D/1/8/D1869DEC-2638-4854-81B7-0F37455F35EA/SQLEXPR_x64_ENU.exe'
         when '2012' then 'https://download.microsoft.com/download/8/D/D/8DD7BDBA-CEF7-4D8E-8C16-D9F69527F909/ENU/x64/SQLEXPR_x64_ENU.exe'
         when '2014' then 'https://download.microsoft.com/download/E/A/E/EAE6F7FC-767A-4038-A954-49B8B05D04EB/Express%2064BIT/SQLEXPR_x64_ENU.exe'
-        when '2016' then 'https://download.microsoft.com/download/9/A/E/9AE09369-C53D-4FB7-985B-5CF0D547AE9F/SQLServer2016-SSEI-Expr.exe'
+        when '2016' then 'https://download.microsoft.com/download/9/0/7/907AD35F-9F9C-43A5-9789-52470555DB90/ENU/SQLEXPR_x64_ENU.exe'
         end
       else
         case version.to_s
@@ -90,7 +90,7 @@ module SqlServer
         when '2008R2' then '8ebf6bdd805f3326d5b9a35a129af276c7fe99bfca64ac0cfe0ffc66311dfe09'
         when '2012' then '7f5e3d40b85fba2da5093e3621435c209c4ac90d34219bab8878e93a787cf29f'
         when '2014' then '8f712faefee9cef1d15494c9d6cf5ad3b45ec06d0b2c247f8384a221baaadda7'
-        when '2016' then 'bdb84067de0187234673de73216818fcfd774501307e84b8cba327b948ef4ca6'
+        when '2016' then '2A5B64AE64A8285C024870EC4643617AC5146894DD59DD560E75CEA787BF9333'
         end
       else
         case version.to_s


### PR DESCRIPTION
### Description

Update the SQL Server 2016 url for SQL Express with SP1, add the checksum, fix the Readme to show support for SQL 2016 Express, and add the CI/CD test to make sure it passes kitchen.

### Issues Resolved

This was a request made to support SQL 2016

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
