### PR TITLE
Add configure custom resource.

### DIFF
--- a/resources/configure.rb
+++ b/resources/configure.rb
@@ -1,0 +1,93 @@
+
+#
+# Cookbook:: sql_server
+# Resource:: install
+#
+# Copyright:: 2017, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+property :reg_version, String
+property :version, String, default: '2012'
+property :tcp_enabled, [true, false], default: true
+property :sql_port, Integer, default: 1433
+property :tcp_dynamic_ports, String, default: ''
+property :np_enabled, [true, false], default: false
+property :sm_enabled, [true, false], default: true
+property :via_default_port, String, default: '0:1433'
+property :via_enabled, [true, false], default: false
+property :via_listen_info, String, default: '0:1433'
+property :agent_startup, String, equal_to: ['Automatic', 'Manual', 'Disabled', 'Automatic (Delayed Start)'], default: 'Disabled'
+
+action :service do
+  # Compute service name based on sql server instance name defined as the resource name
+  service_name = (new_resource.name != 'MSSQLSERVER') ? "MSSQL$#{new_resource.name}" : new_resource.name
+
+  # Agent name needs to be declared because if you use the SQL Agent, you need
+  # to restart both services as the Agent is dependent on the SQL Service
+  agent_service_name = (new_resource.name == 'MSSQLSERVER') ? 'SQLSERVERAGENT' : "SQLAgent$#{new_resource.name}"
+
+  # Compute registry version based on sql server version
+  reg_version = new_resource.reg_version || ::SqlServer::Helper.reg_version_string(new_resource.version)
+
+  reg_prefix = "HKLM\\SOFTWARE\\Microsoft\\Microsoft SQL Server\\#{reg_version}#{new_resource.name}\\MSSQLServer"
+
+  # Configure Tcp settings - static tcp ports
+  registry_key "#{reg_prefix}\\SuperSocketNetLib\\Tcp\\IPAll" do
+    values [{ name: 'Enabled', type: :dword, data: new_resource.tcp_enabled ? 1 : 0 },
+            { name: 'TcpPort', type: :string, data: new_resource.sql_port.to_s },
+            { name: 'TcpDynamicPorts', type: :string, data: new_resource.tcp_dynamic_ports.to_s }]
+    recursive true
+    notifies :restart, "service[#{service_name}]", :immediately
+  end
+
+  # Configure Named Pipes settings
+  registry_key "#{reg_prefix}\\SuperSocketNetLib\\Np" do
+    values [{ name: 'Enabled', type: :dword, data: new_resource.np_enabled ? 1 : 0 }]
+    recursive true
+    notifies :restart, "service[#{service_name}]", :immediately
+  end
+
+  # Configure Shared Memory settings
+  registry_key "#{reg_prefix}\\SuperSocketNetLib\\Sm" do
+    values [{ name: 'Enabled', type: :dword, data: new_resource.sm_enabled ? 1 : 0 }]
+    recursive true
+    notifies :restart, "service[#{service_name}]", :immediately
+  end
+
+  # Configure Via settings
+  registry_key "#{reg_prefix}\\SuperSocketNetLib\\Via" do
+    values [{ name: 'DefaultServerPort', type: :string, data: new_resource.via_default_port.to_s },
+            { name: 'Enabled', type: :dword, data: new_resource.via_enabled ? 1 : 0 },
+            { name: 'ListenInfo', type: :string, data: new_resource.via_listen_info.to_s }]
+    recursive true
+    notifies :restart, "service[#{service_name}]", :immediately
+  end
+
+  # If you have declared an agent account it will restart both the
+  # agent service and the sql service. If not only the sql service
+  if new_resource.agent_startup == 'Automatic'
+    service agent_service_name do
+      action [:start, :enable]
+    end
+  end
+
+  service service_name do
+    action [:start, :enable]
+    restart_command %(powershell.exe -C "restart-service '#{service_name}' -force")
+  end
+end
+
+action_class do
+  include ::SqlServer::Helper
+end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -55,6 +55,7 @@ property :filestream_share_name, String, default: 'MSSQLSERVER'
 property :sql_collation, String
 property :dreplay_ctlr_admins, [Array, String], default: ['Administrator']
 property :dreplay_client_name, String
+property :netfx35_source, String
 
 action :install do
   if new_resource.feature.include?('DREPLAY_CLT') && new_resource.dreplay_client_name.nil?
@@ -63,6 +64,12 @@ action :install do
 
   if new_resource.security_mode == 'Mixed Mode Authentication' && new_resource.sa_password.nil?
     ::Chef::Application.fatal!('You cannot have set the security mode to "Mixed Mode Authenication" without specifying the sa_password property')
+  end
+
+  windows_feature 'NET-Framework-Core' do
+    action :install
+    source new_resource.netfx35_source if new_resource.netfx35_source
+    install_methos :windows_feature_powershell
   end
 
   config_file_path = ::File.join(Chef::Config[:file_cache_path], 'ConfigurationFile.ini')

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -66,7 +66,7 @@ action :install do
     ::Chef::Application.fatal!('You cannot have set the security mode to "Mixed Mode Authenication" without specifying the sa_password property')
   end
 
-  windows_feature 'NET-Framework-Core' do
+  windows_feature ['NET-Framework-Features', 'NET-Framework-Core'] do
     action :install
     source new_resource.netfx35_source if new_resource.netfx35_source
     install_method :windows_feature_powershell

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 property :sql_reboot, [true, false], default: true
-property :security_mode, String, equal_to: ['Windows Authenication', 'Mixed Mode Authentication'], default: 'Windows Authenication'
+property :security_mode, String, equal_to: ['Windows Authentication', 'Mixed Mode Authentication'], default: 'Windows Authentication'
 property :sa_password, String
 property :sysadmins, [Array, String], default: ['Administrator']
 property :agent_account, String, default: 'NT AUTHORITY\NETWORK SERVICE'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -69,7 +69,7 @@ action :install do
   windows_feature 'NET-Framework-Core' do
     action :install
     source new_resource.netfx35_source if new_resource.netfx35_source
-    install_methos :windows_feature_powershell
+    install_method :windows_feature_powershell
   end
 
   config_file_path = ::File.join(Chef::Config[:file_cache_path], 'ConfigurationFile.ini')

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -22,7 +22,7 @@ property :security_mode, String, equal_to: ['Windows Authenication', 'Mixed Mode
 property :sa_password, String
 property :sysadmins, [Array, String], default: ['Administrator']
 property :agent_account, String, default: 'NT AUTHORITY\NETWORK SERVICE'
-property :agent_startup, String, equal_to: ['Automatic', 'Manual', 'Disabled', 'Automatic (Delayed Start)'], default: 'Automatic'
+property :agent_startup, String, equal_to: ['Automatic', 'Manual', 'Disabled', 'Automatic (Delayed Start)'], default: 'Disabled'
 property :agent_account_pwd, String
 property :rs_account, String, default: 'NT AUTHORITY\NETWORK SERVICE'
 property :rs_account_pwd, String

--- a/test/cookbooks/test/recipes/install.rb
+++ b/test/cookbooks/test/recipes/install.rb
@@ -6,4 +6,4 @@ sql_server_install 'Install SQL' do
   action :install
 end
 
-include_recipe 'sql_server::configure'
+sql_server_configure 'SQLEXPRESS'


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

### Description

Add a custom resource for configuring SQL post installation

Fix an issue where the default value of the agent_startup was set to Automatic even though the agent is not supported on SQLExpress.

### Issues Resolved



### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
