### PR TITLE
Add update_source property to config.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ NOTE: Install of SQL Server 2016 and SQL Server 2017 is not supported on Server 
    Note: For SQL 2016 if this will also accept the license for using R if `ADVANCEDANALYTICS` or `SQL_SHARED_MR` is listed in the feature property array.
 - `product_key` - Product key for not Express or Evaluation versions.
 - `update_enabled` - Whether or not to download updates during install. Default is true.
+- `update_source` - The Source Location of Windows Update or WSUS. Default is `MU`. Example = `c:/path/to/update`
 - `instance_name` - Name for the instance to be installed. Default is `SQLEXPRESS`. For non-express installs that want the default install it should be set to `MSSQLSERVER`.
 - `install_dir` - Directory SQL binaries will be installed to. Default is `C:\Program Files\Microsoft SQL Server`
 - `instance_dir` - Directory the Instance will be stored. Default is `C:\Program Files\Microsoft SQL Server`

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -40,6 +40,7 @@ property :installer_timeout, Integer, default: 1500
 property :accept_eula, [true, false], default: false
 property :product_key, String
 property :update_enabled, [true, false], default: true
+property :update_source, String, default: 'MU'
 property :instance_name, String, default: 'SQLEXPRESS'
 property :feature, [Array, String], default: %w(SQLENGINE REPLICATION SNAC_SDK)
 property :install_dir, String, default: 'C:\Program Files\Microsoft SQL Server'
@@ -99,6 +100,7 @@ action :install do
       agent_account: new_resource.agent_account,
       agent_startup: new_resource.agent_startup,
       update_enabled: new_resource.update_enabled,
+      update_source: new_resource.update_source,
       instance_name: new_resource.instance_name,
       feature_list: new_resource.feature,
       install_dir: new_resource.install_dir,

--- a/templates/default/_ConfigurationFile.ini.erb
+++ b/templates/default/_ConfigurationFile.ini.erb
@@ -28,6 +28,10 @@ SAPWD="<%= @sa_password %>"
 UpdateEnabled="<%= @update_enabled ? "True" : "False" %>"
 <% end %>
 
+; Specify the location where SQL Server Setup will obtain product updates. The valid values are "MU" to search Microsoft Update, a valid folder path, a relative path such as .\MyUpdates or a UNC share. By default SQL Server Setup will search Microsoft Update or a Windows Update service through the Window Server Update Services.
+
+UpdateSource= "<%= @update_source %>"
+
 ; Specify the Instance ID for the SQL Server features you have specified. SQL Server directory structure, registry structure, and service names will reflect the instance ID of the SQL Server instance.
 
 INSTANCEID="<%= @instance_name %>"


### PR DESCRIPTION
Signed-off-by: Matt Reynolds <thebeardgrammer@gmail.com>

### Description

For an air-gapped environment where SQL server updates are pulled during installation, this creates a property that allows adding a different source for update_source with the default value being 'MU' 

### Issues Resolved

N/A

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
