### PR TITLE
Fix feature variable name in template config file

### DIFF
--- a/templates/default/_ConfigurationFile.ini.erb
+++ b/templates/default/_ConfigurationFile.ini.erb
@@ -327,7 +327,7 @@ CLTWORKINGDIR="WorkingDir"
 <% end %>
 
 <% if @version == '2016' %>
-<% if @feature.include?('ADVANCEDANALYTICS' || 'SQL_SHARED_MR') %>
+<% if @feature_list.include?('ADVANCEDANALYTICS' || 'SQL_SHARED_MR') %>
 IACCEPTROPENLICENSETERMS=<%= @accept_eula %>
 
 EXTSVCACCOUNT="NT Service\MSSQLLaunchpad"
@@ -335,7 +335,7 @@ EXTSVCACCOUNT="NT Service\MSSQLLaunchpad"
 <% end %>
 
 <% if (@version == '2016') || (@version == '2017') %>
-<% if @feature.include?('POLYBASE') %>
+<% if @feature_list.include?('POLYBASE') %>
 ; PolybasePdwUserNameConfigDescription
 
 PBENGSVCACCOUNT="NT AUTHORITY\NETWORK SERVICE"
@@ -363,19 +363,19 @@ PBPORTRANGE="<%= @polybase_port_range %>"
 <% end %>
 
 <% if @version == '2017' %>
-<% if @feature.include?('SQL_INST_MR' || 'SQL_SHARED_MR' || 'SQL_SHARED_AA') %>
+<% if @feature_list.include?('SQL_INST_MR' || 'SQL_SHARED_MR' || 'SQL_SHARED_AA') %>
 IACCEPTROPENLICENSETERMS=<%= @accept_eula %>
 <% end%>
 
-<% if @feature.include?('SQL_INST_MPY' || 'SQL_SHARED_MPY' || 'SQL_SHARED_AA') %>
+<% if @feature_list.include?('SQL_INST_MPY' || 'SQL_SHARED_MPY' || 'SQL_SHARED_AA') %>
 IACCEPTPYTHONLICENSETERMS=<%= @accept_eula %>
 <% end %>
 
-<% if @feature.include?('ADVANCEDANALYTICS') %>
+<% if @feature_list.include?('ADVANCEDANALYTICS') %>
 EXTSVCACCOUNT="NT Service\MSSQLLaunchpad"
 <% end %>
 
-<% if @feature.include?('IS_MASTER')%>
+<% if @feature_list.include?('IS_MASTER')%>
 ; Startup type for Integration Services Scale Out Master service.
 
 ISMASTERSVCSTARTUPTYPE="Automatic"
@@ -399,7 +399,7 @@ ISMASTERSVCTHUMBPRINT=<%= @is_master_cert_thumbprint %>
 <% end %>
 <% end %>
 
-<% if @feature.include?('IS_WORKER') %>
+<% if @feature_list.include?('IS_WORKER') %>
 ; Startup type for Integration Services Scale Out Worker service.
 
 ISWORKERSVCSTARTUPTYPE="Automatic"


### PR DESCRIPTION
replace "feature" variable name with "feature_list" in some case in _ConfigurationFile.ini.erb file. This syntax error impede the cookbook to run install of 2016 or 2017 versions of MSSQL Server with the following error:  undefined method `include?' for nil:NilClass.

### Description

Fix this error:  FATAL: Chef::Mixin::Template::TemplateError: undefined method `include?' for nil:NilClass
Template Context:
-----------------
on line #330
328:
329: <% if @version == '2016' %>
330: <% if @feature.include?('ADVANCEDANALYTICS' || 'SQL_SHARED_MR') %>
331: IACCEPTROPENLICENSETERMS=<%= @accept_eula %>
332:

System Info:
------------
chef_version=13.0.118
platform=windows
platform_version=6.3.9600
ruby=ruby 2.4.1p111 (2017-03-22 revision 58053) [x64-mingw32]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
