### PR TITLE
Add property to make .Net 3.5 install optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ NOTE: Install of SQL Server 2016 and SQL Server 2017 is not supported on Server 
 - `filestream_level` - Level to enable the filestream feature, Valid values are 0, 1, 2 or 3. Default is 0
 - `filestream_share_name` - Share name for the filestream feature. Default is `MSSQLSERVER`
 - `sql_collation` - SQL Collation type for the instance
+- `netfx35_install` - If the .Net 3.5 Windows Feature is installed. This is required to successfully install SQL 2012 and 2014. Default is true.
 - `netfx35_source` - Source location for the .Net 3.5 Windows Features install. Only required for offline installs
 
 Distributed Replay

--- a/resources/configure.rb
+++ b/resources/configure.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 
 property :reg_version, String
-property :version, String, default: '2012'
+property :version, [Integer, String], default: '2012'
 property :tcp_enabled, [true, false], default: true
 property :sql_port, Integer, default: 1433
 property :tcp_dynamic_ports, String, default: ''

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -32,7 +32,7 @@ property :as_sysadmins, [Array, String], default: ['Administrator']
 property :sql_account, String, default: 'NT AUTHORITY\NETWORK SERVICE'
 property :sql_account_pwd, String
 property :browser_startup, String, equal_to: ['Automatic', 'Manual', 'Disabled', 'Automatic (Delayed Start)'], default: 'Disabled'
-property :version, String, default: '2012'
+property :version, [Integer, String], default: '2012'
 property :source_url, String
 property :package_name, String
 property :package_checksum, String
@@ -56,6 +56,7 @@ property :filestream_share_name, String, default: 'MSSQLSERVER'
 property :sql_collation, String
 property :dreplay_ctlr_admins, [Array, String], default: ['Administrator']
 property :dreplay_client_name, String
+property :netfx35_install, [true, false], default: true
 property :netfx35_source, String
 property :polybase_port_range, String, default: '16450-16460'
 property :is_master_port, String, default: '8391'
@@ -72,10 +73,12 @@ action :install do
     ::Chef::Application.fatal!('You cannot have set the security mode to "Mixed Mode Authenication" without specifying the sa_password property')
   end
 
-  windows_feature ['NET-Framework-Features', 'NET-Framework-Core'] do
-    action :install
-    source new_resource.netfx35_source if new_resource.netfx35_source
-    install_method :windows_feature_powershell
+  if new_resource.netfx35_install
+    windows_feature ['NET-Framework-Features', 'NET-Framework-Core'] do
+      action :install
+      source new_resource.netfx35_source if new_resource.netfx35_source
+      install_method :windows_feature_powershell
+    end
   end
 
   config_file_path = ::File.join(Chef::Config[:file_cache_path], 'ConfigurationFile.ini')

--- a/test/cookbooks/test/recipes/enterprise.rb
+++ b/test/cookbooks/test/recipes/enterprise.rb
@@ -1,0 +1,16 @@
+# Test suite for testing the Enterprise editiions of SQL Server THIS WILL NOT WORK WITHOUT LOCAL INSTALL FILES
+
+# Install any version of SQL Engine
+sql_server_install "Install SQL Server #{node['sql_server']['version']}" do
+  source_url "C:\\Sources\\SQL_#{node['sql_server']['version']}\\setup.exe"
+  version node['sql_server']['version']
+  package_checksum node['sql_server']['server']['checksum']
+  accept_eula true
+  instance_name 'MSSQLSERVER'
+  netfx35_install false if node['sql_server']['version'] == 2016
+  feature %w(SQLENGINE)
+end
+
+sql_server_configure 'MSSQLSERVER' do
+  version node['sql_server']['version']
+end

--- a/test/integration/enterprise/enterprise.rb
+++ b/test/integration/enterprise/enterprise.rb
@@ -1,0 +1,3 @@
+describe port(1433) do
+  it { should be_listening }
+end


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

The .Net 3.5 install is not required for SQL 2016 but is required for all previous versions of SQL. Additional this PR fixes an issue when passing in an Integer for the version which is being validated in the helper library.

[Describe what this change achieves]

#115 

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
